### PR TITLE
add citation suggestions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,72 @@ References & Acknowledgments
 ****************************
 Papers making use of Bioverse should cite `Bixel & Apai (2021) <https://ui.adsabs.harvard.edu/abs/2021AJ....161..228B/abstract>`_, `Hardegree-Ullman et al. (2023) <https://ui.adsabs.harvard.edu/abs/2023AJ....165..267H/abstract>`_, and `Schlecker et al. (2024) <https://ui.adsabs.harvard.edu/abs/2024PSJ.....5....3S/abstract>`_. ::
 
+ @ARTICLE{2021AJ....161..228B,
+   author = {{Bixel}, Alex and {Apai}, D{\'a}niel},
+   title = "{Bioverse: A Simulation Framework to Assess the Statistical Power of Future Biosignature Surveys}",
+   journal = {\aj},
+   keywords = {Astrobiology, Exoplanets, Exoplanet atmospheres, Astrostatistics, Open source software, 74, 498, 487, 1882, 1866, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
+   year = 2021,
+   month = may,
+   volume = {161},
+   number = {5},
+   eid = {228},
+   pages = {228},
+   doi = {10.3847/1538-3881/abe042},
+ archivePrefix = {arXiv},
+   eprint = {2101.10393},
+   primaryClass = {astro-ph.EP},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2021AJ....161..228B},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+ }
+
+::
+
+ @ARTICLE{2023AJ....165..267H,
+   author = {{Hardegree-Ullman}, Kevin K. and {Apai}, D{\'a}niel and {Bergsten}, Galen J. and {Pascucci}, Ilaria and {L{\'o}pez-Morales}, Mercedes},
+   title = "{Bioverse: A Comprehensive Assessment of the Capabilities of Extremely Large Telescopes to Probe Earth-like O$_{2}$ Levels in Nearby Transiting Habitable-zone Exoplanets}",
+   journal = {\aj},
+   keywords = {Fundamental parameters of stars, Exoplanet systems, Exoplanets, Exoplanet atmospheres, Biosignatures, 555, 484, 498, 487, 2018, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+   year = 2023,
+   month = jun,
+   volume = {165},
+   number = {6},
+   eid = {267},
+   pages = {267},
+   doi = {10.3847/1538-3881/acd1ec},
+ archivePrefix = {arXiv},
+   eprint = {2304.12490},
+   primaryClass = {astro-ph.EP},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2023AJ....165..267H},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+ }
+
+::
+
+ @ARTICLE{2024PSJ.....5....3S,
+   author = {{Schlecker}, Martin and {Apai}, D{\'a}niel and {Lichtenberg}, Tim and {Bergsten}, Galen and {Salvador}, Arnaud and {Hardegree-Ullman}, Kevin K.},
+   title = "{Bioverse: The Habitable Zone Inner Edge Discontinuity as an Imprint of Runaway Greenhouse Climates on Exoplanet Demographics}",
+   journal = {\psj},
+   keywords = {Habitable zone, Habitable planets, Astrobiology, Extrasolar rocky planets, Planetary climates, Exoplanet atmospheres, Astronomical simulations, Exoplanets, Transit photometry, Radial velocity, Bayesian statistics, Parametric hypothesis tests, 696, 695, 74, 511, 2184, 487, 1857, 498, 1709, 1332, 1900, 1904, Astrophysics - Earth and Planetary Astrophysics},
+   year = 2024,
+   month = jan,
+   volume = {5},
+   number = {1},
+   eid = {3},
+   pages = {3},
+   doi = {10.3847/PSJ/acf57f},
+   archivePrefix = {arXiv},
+   eprint = {2309.04518},
+   primaryClass = {astro-ph.EP},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2024PSJ.....5....3S},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+ }
+
+
+
+If you make use of the integrated hypothesis testing and parameter fitting, you should also include references to the `emcee <https://github.com/dfm/emcee>`_ and `dynesty <https://github.com/joshspeagle/dynesty>`_ packages.
+
+
 
 Bioverse was developed with support from the following grants and collaborations:
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,8 @@ For documentation, see https://bioverse.readthedocs.io/.
 
 References & Acknowledgments
 ****************************
-Papers making use of Bioverse should reference `Bixel & Apai (2021) <https://ui.adsabs.harvard.edu/abs/2021AJ....161..228B/abstract>`_. You should also include references to the `emcee <https://github.com/dfm/emcee>`_ and `dynesty <https://github.com/joshspeagle/dynesty>`_ packages, which are used for hypothesis testing and parameter fitting.
+Papers making use of Bioverse should cite `Bixel & Apai (2021) <https://ui.adsabs.harvard.edu/abs/2021AJ....161..228B/abstract>`_, `Hardegree-Ullman et al. (2023) <https://ui.adsabs.harvard.edu/abs/2023AJ....165..267H/abstract>`_, and `Schlecker et al. (2024) <https://ui.adsabs.harvard.edu/abs/2024PSJ.....5....3S/abstract>`_. ::
+
 
 Bioverse was developed with support from the following grants and collaborations:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,74 @@ Bioverse is open source and in active development. We welcome all feedback, bug 
 
 References & Acknowledgements
 *****************************
-Papers making use of Bioverse should reference `Bixel & Apai (2021) <https://ui.adsabs.harvard.edu/abs/2021AJ....161..228B/abstract>`_. You should also include references to the `emcee <https://github.com/dfm/emcee>`_ and `dynesty <https://github.com/joshspeagle/dynesty>`_ packages, which are used for hypothesis testing and parameter fitting.
+Papers making use of Bioverse should cite `Bixel & Apai (2021) <https://ui.adsabs.harvard.edu/abs/2021AJ....161..228B/abstract>`_, `Hardegree-Ullman et al. (2023) <https://ui.adsabs.harvard.edu/abs/2023AJ....165..267H/abstract>`_, and `Schlecker et al. (2024) <https://ui.adsabs.harvard.edu/abs/2024PSJ.....5....3S/abstract>`_. ::
+
+ @ARTICLE{2021AJ....161..228B,
+   author = {{Bixel}, Alex and {Apai}, D{\'a}niel},
+   title = "{Bioverse: A Simulation Framework to Assess the Statistical Power of Future Biosignature Surveys}",
+   journal = {\aj},
+   keywords = {Astrobiology, Exoplanets, Exoplanet atmospheres, Astrostatistics, Open source software, 74, 498, 487, 1882, 1866, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
+   year = 2021,
+   month = may,
+   volume = {161},
+   number = {5},
+   eid = {228},
+   pages = {228},
+   doi = {10.3847/1538-3881/abe042},
+ archivePrefix = {arXiv},
+   eprint = {2101.10393},
+   primaryClass = {astro-ph.EP},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2021AJ....161..228B},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+ }
+
+::
+
+ @ARTICLE{2023AJ....165..267H,
+   author = {{Hardegree-Ullman}, Kevin K. and {Apai}, D{\'a}niel and {Bergsten}, Galen J. and {Pascucci}, Ilaria and {L{\'o}pez-Morales}, Mercedes},
+   title = "{Bioverse: A Comprehensive Assessment of the Capabilities of Extremely Large Telescopes to Probe Earth-like O$_{2}$ Levels in Nearby Transiting Habitable-zone Exoplanets}",
+   journal = {\aj},
+   keywords = {Fundamental parameters of stars, Exoplanet systems, Exoplanets, Exoplanet atmospheres, Biosignatures, 555, 484, 498, 487, 2018, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+   year = 2023,
+   month = jun,
+   volume = {165},
+   number = {6},
+   eid = {267},
+   pages = {267},
+   doi = {10.3847/1538-3881/acd1ec},
+ archivePrefix = {arXiv},
+   eprint = {2304.12490},
+   primaryClass = {astro-ph.EP},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2023AJ....165..267H},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+ }
+
+::
+
+ @ARTICLE{2024PSJ.....5....3S,
+   author = {{Schlecker}, Martin and {Apai}, D{\'a}niel and {Lichtenberg}, Tim and {Bergsten}, Galen and {Salvador}, Arnaud and {Hardegree-Ullman}, Kevin K.},
+   title = "{Bioverse: The Habitable Zone Inner Edge Discontinuity as an Imprint of Runaway Greenhouse Climates on Exoplanet Demographics}",
+   journal = {\psj},
+   keywords = {Habitable zone, Habitable planets, Astrobiology, Extrasolar rocky planets, Planetary climates, Exoplanet atmospheres, Astronomical simulations, Exoplanets, Transit photometry, Radial velocity, Bayesian statistics, Parametric hypothesis tests, 696, 695, 74, 511, 2184, 487, 1857, 498, 1709, 1332, 1900, 1904, Astrophysics - Earth and Planetary Astrophysics},
+   year = 2024,
+   month = jan,
+   volume = {5},
+   number = {1},
+   eid = {3},
+   pages = {3},
+   doi = {10.3847/PSJ/acf57f},
+   archivePrefix = {arXiv},
+   eprint = {2309.04518},
+   primaryClass = {astro-ph.EP},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2024PSJ.....5....3S},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+ }
+
+
+
+If you make use of the integrated hypothesis testing and parameter fitting, you should also include references to the `emcee <https://github.com/dfm/emcee>`_ and `dynesty <https://github.com/joshspeagle/dynesty>`_ packages.
+
+
 
 Bioverse was developed with support from the following grants and collaborations:
 


### PR DESCRIPTION
Instead of just Bixel & Apai 2021, we suggest that Bioverse users also cite the more recent Bioverse papers that expanded the framework. 