### PR TITLE
New hz formulations

### DIFF
--- a/bioverse/constants.py
+++ b/bioverse/constants.py
@@ -40,3 +40,14 @@ FLOAT_TYPES = (float,np.double,np.float64)
 INT_TYPES = (int,np.int_,np.int64,np.integer,np.int8)
 STR_TYPES = (str,np.str_)
 BOOL_TYPES = (bool,np.bool_)
+
+#Constants for HZ polynomials
+#Seff_sun, a,b,c,d
+HZ_CONST={'recent_venus': [1.7763,1.4335e-4,3.3954e-9,-7.6364e-12,-1.1950e-15], #From Kopparapu 2013
+          'runaway_greenhouse': [1.0385,1.2456e-4,1.4612e-8,-7.6345e-12,-1.1950e-15],
+          'moist_greenhouse':[1.0146,8.1884e-5,1.9394e-9,-4.3618e-12, -6.8260e-16],
+          'max_greenhouse': [0.3507, 5.9578e-5,1.6707e-9,-3.0058e-12,-5.1925e-16],
+          'early_mars': [0.3207, 5.4471e-5,1.5275e-9,-2.1709e-12,-3.8282e-16],
+          'leconte': [1.105, 1.1921e-4, 9.5932e-9, -2.6189e-12, 1.3710e-16], #From Ramirez 2018
+          'CO2_max': [0.3587,5.8087e-5,1.5393e-9,-8.3547e-13,1.0319e-16]
+}

--- a/bioverse/functions.py
+++ b/bioverse/functions.py
@@ -1022,7 +1022,7 @@ def compute_habitable_zone_boundaries(d,HZ_formulation='K14'):
         Formulation of the habitable zone to use. Options are:
         'K14' : Kopparapu et al. (2014) HZ, including dependence on planet mass
         'K13': Kopparapu el al. (2013) HZ, conservative (moist greenhouse,max_greenhouse)
-        'K13_optimistic': Kopparapu+ 2013 HZ, optimistic base on recent Venus and early mars
+        'K13_optimistic': Kopparapu+ 2013 HZ, optimistic base on recent Venus and early Mars
         'R18': Ramirez et al. (2018) HZ, including methane
 
     Returns

--- a/bioverse/functions.py
+++ b/bioverse/functions.py
@@ -1116,19 +1116,6 @@ def compute_habitable_zone_boundaries(d,HZ_formulation='K14'):
     return d
 
 
-    # By default planets are in the 'None' zone
-    #zones = np.full(len(d),'None',dtype='<U20')
-    
-    # Kopparapu+2014 limits
-    #zones[d['a0']<=d['a_inner']] = 'runaway'
-    #zones[d['a0']>=d['a_outer']] = 'maximum'
-    #zones[(d['a0']>d['a_inner'])&(d['a0']<d['a_outer'])] = 'temperate'
-    
-    # Kane+2014 "Venus zone" inner edge (also e.g. Zahnle+2013)
-    #zones[d['S']>25] = 'hot'
-
-    #d['zone'] = zones
-
 
 
 def scale_height(d):

--- a/bioverse/functions.py
+++ b/bioverse/functions.py
@@ -19,7 +19,7 @@ warnings.filterwarnings("ignore")
 from .classes import Table
 from . import util
 from .util import CATALOG, interpolate_df, lambertian_phase
-from .constants import CONST, ROOT_DIR, DATA_DIR
+from .constants import CONST, ROOT_DIR, DATA_DIR, HZ_CONST
 
 def luminosity_evolution(d):
     """
@@ -1010,7 +1010,7 @@ def classify_planets(d):
 
     return d
 
-def compute_habitable_zone_boundaries(d):
+def compute_habitable_zone_boundaries(d,HZ_formulation='K14'):
     """ Computes the habitable zone boundaries from Kopparapu et al. (2014), including
     dependence on planet mass.
 
@@ -1018,6 +1018,12 @@ def compute_habitable_zone_boundaries(d):
     ----------
     d : Table
         Table containing the sample of simulated planets.
+    HZ_formulation: str, optional
+        Formulation of the habitable zone to use. Options are:
+        'K14' : Kopparapu et al. (2014) HZ, including dependence on planet mass
+        'K13': Kopparapu el al. (2013) HZ, conservative (moist greenhouse,max_greenhouse)
+        'K13_optimistic': Kopparapu+ 2013 HZ, optimistic base on recent Venus and early mars
+        'R18': Ramirez et al. (2018) HZ, including methane
 
     Returns
     -------
@@ -1026,63 +1032,103 @@ def compute_habitable_zone_boundaries(d):
     """
     L,T_eff = d['L_st'],d['T_eff_st']
     M_pl = d['M']
-    
-    # Parameters for each planet mass and boundary (Table 1)
-    M_ref = np.array([0.1,1.,5.])
-    S_eff_sol = np.array([[1.776,0.99,0.356,0.32],
-                          [1.776,1.107,0.356,0.32],
-                          [1.776,1.188,0.356,0.32]])
-    a = np.array([[2.136e-4,1.209e-4,6.171e-5,5.547e-5],
-                  [2.136e-4,1.332e-4,6.171e-5,5.547e-5],
-                  [2.136e-4,1.433e-4,6.171e-5,5.547e-5]])
-    b = np.array([[2.533e-5,1.404e-8,1.698e-9,1.526e-9],
-                  [2.533e-5,1.58e-8,1.698e-9,1.526e-9],
-                  [2.533e-5,1.707e-8,1.698e-9,1.526e-9]])
-    c = np.array([[-1.332e-11,-7.418e-12,-3.198e-12,-2.874e-12],
-                  [-1.332e-11,-8.308e-12,-3.198e-12,-2.874e-12],
-                  [-1.332e-11,-8.968e-12,-3.198e-12,-2.874e-12]])
-    d2 = np.array([[-3.097e-15,-1.713e-15,-5.575e-16,-5.011e-16],
-                  [-3.097e-15,-1.931e-15,-5.575e-16,-5.011e-16],
-                  [-3.097e-15,-2.084e-15,-5.575e-16,-5.011e-16]])
-    
-    # Interpolate in mass to estimate the constant values for each planet
-    S_eff_sol0 = np.array([np.interp(M_pl,M_ref,S_eff_sol[:,i]) for i in range(len(S_eff_sol[0]))])
-    a = np.array([np.interp(M_pl,M_ref,a[:,i]) for i in range(len(a[0]))])
-    b = np.array([np.interp(M_pl,M_ref,b[:,i]) for i in range(len(b[0]))])
-    c = np.array([np.interp(M_pl,M_ref,c[:,i]) for i in range(len(c[0]))])
-    d2 = np.array([np.interp(M_pl,M_ref,d2[:,i]) for i in range(len(d2[0]))])
-    
-    # Calculate the effective stellar flux at each boundary (Equation 4)
-    T_st = T_eff-5780.
-    S_eff = S_eff_sol0+a*T_st+b*T_st**2+c*T_st**3+d2*T_st**4
-    
-    # The corresponding distances in AU (stars with T_eff > 7200 K are not habitable so d = inf)
-    Tm = T_eff<7200
-    dist = (L/S_eff)**0.5
-    dist[:,~Tm] = np.inf
 
-    # Inner, outer HZ bounds for each planet
-    d_in,d_out = dist[1],dist[2]
-    d['a_inner'],d['a_outer'] = d_in,d_out
-    d['S_inner'],d['S_outer'] = S_eff[1],S_eff[2]
+    if HZ_formulation == 'K14':
+        #from Kopparapu et al. (2014), including dependence on planet mass.
+        # Parameters for each planet mass and boundary (Table 1)
+        M_ref = np.array([0.1,1.,5.])
+        S_eff_sol = np.array([[1.776,0.99,0.356,0.32],
+                              [1.776,1.107,0.356,0.32],
+                              [1.776,1.188,0.356,0.32]])
+        a = np.array([[2.136e-4,1.209e-4,6.171e-5,5.547e-5],
+                      [2.136e-4,1.332e-4,6.171e-5,5.547e-5],
+                      [2.136e-4,1.433e-4,6.171e-5,5.547e-5]])
+        b = np.array([[2.533e-5,1.404e-8,1.698e-9,1.526e-9],
+                      [2.533e-5,1.58e-8,1.698e-9,1.526e-9],
+                      [2.533e-5,1.707e-8,1.698e-9,1.526e-9]])
+        c = np.array([[-1.332e-11,-7.418e-12,-3.198e-12,-2.874e-12],
+                      [-1.332e-11,-8.308e-12,-3.198e-12,-2.874e-12],
+                      [-1.332e-11,-8.968e-12,-3.198e-12,-2.874e-12]])
+        d2 = np.array([[-3.097e-15,-1.713e-15,-5.575e-16,-5.011e-16],
+                      [-3.097e-15,-1.931e-15,-5.575e-16,-5.011e-16],
+                      [-3.097e-15,-2.084e-15,-5.575e-16,-5.011e-16]])
+
+        # Interpolate in mass to estimate the constant values for each planet
+        S_eff_sol0 = np.array([np.interp(M_pl,M_ref,S_eff_sol[:,i]) for i in range(len(S_eff_sol[0]))])
+        a = np.array([np.interp(M_pl,M_ref,a[:,i]) for i in range(len(a[0]))])
+        b = np.array([np.interp(M_pl,M_ref,b[:,i]) for i in range(len(b[0]))])
+        c = np.array([np.interp(M_pl,M_ref,c[:,i]) for i in range(len(c[0]))])
+        d2 = np.array([np.interp(M_pl,M_ref,d2[:,i]) for i in range(len(d2[0]))])
+    
+        # Calculate the effective stellar flux at each boundary (Equation 4)
+        T_st = T_eff-5780.
+        S_eff = S_eff_sol0+a*T_st+b*T_st**2+c*T_st**3+d2*T_st**4
+    
+        # The corresponding distances in AU (stars with T_eff > 7200 K are not habitable so d = inf)
+        Tm = T_eff<7200
+        dist = (L/S_eff)**0.5
+        dist[:,~Tm] = np.inf
+
+        # Inner, outer HZ bounds for each planet
+        d_in,d_out = dist[1],dist[2]
+        S_in,S_out = S_eff[1],S_eff[2]
+        d['a_inner'], d['a_outer'] = d_in, d_out
+        d['S_inner'], d['S_outer'] = S_in, S_out
+
+        # Compute the mean semi-major axis
+        d['a0'] = d['a'] / (1 - d['e'] ** 2) ** 0.5
+        return d
+
+    if HZ_formulation == 'K13':
+        #Kopparapu+ 2013 HZ formulation
+        C_inner=HZ_CONST['moist_greenhouse']
+        C_outer=HZ_CONST['max_greenhouse']
+        T_max= 7200
+    elif HZ_formulation == 'K13_optimistic':
+        #Kopparapu+ 2013 optimistic HZ
+        C_inner=HZ_CONST['recent_venus']
+        C_outer=HZ_CONST['early_mars']
+        T_max= 7200
+    elif HZ_formulation == 'R18':
+        #Ramirez et al 2018 HZ
+        C_inner=HZ_CONST['leconte']
+        C_outer=HZ_CONST['CO2_max']
+        T_max= 10000
+    else:
+        raise ValueError('HZ formation not recognized')
+
+    T_st = T_eff - 5780.
+    S_in = C_inner[0] + C_inner[1] * T_st + C_inner[2] * T_st ** 2 + C_inner[3] * T_st ** 3 + C_inner[4] * T_st ** 4
+    S_out = C_outer[0] + C_outer[1] * T_st + C_outer[2] * T_st ** 2 + C_outer[3] * T_st ** 3 + C_outer[4] * T_st ** 4
+
+    d_in = (L/S_in)**0.5
+    d_out = (L/S_out)**0.5
+
+    d_in[T_eff>T_max]=np.inf
+    d_out[T_eff>T_max]=np.inf
+
+    d['a_inner'], d['a_outer'] = d_in, d_out
+    d['S_inner'], d['S_outer'] = S_in, S_out
 
     # Compute the mean semi-major axis
-    d['a0'] = d['a']/(1-d['e']**2)**0.5
+    d['a0'] = d['a'] / (1 - d['e'] ** 2) ** 0.5
+
+    return d
+
 
     # By default planets are in the 'None' zone
-    zones = np.full(len(d),'None',dtype='<U20')
+    #zones = np.full(len(d),'None',dtype='<U20')
     
     # Kopparapu+2014 limits
-    zones[d['a0']<=d['a_inner']] = 'runaway'
-    zones[d['a0']>=d['a_outer']] = 'maximum'
-    zones[(d['a0']>d['a_inner'])&(d['a0']<d['a_outer'])] = 'temperate'
+    #zones[d['a0']<=d['a_inner']] = 'runaway'
+    #zones[d['a0']>=d['a_outer']] = 'maximum'
+    #zones[(d['a0']>d['a_inner'])&(d['a0']<d['a_outer'])] = 'temperate'
     
     # Kane+2014 "Venus zone" inner edge (also e.g. Zahnle+2013)
     #zones[d['S']>25] = 'hot'
 
     #d['zone'] = zones
 
-    return d
 
 
 def scale_height(d):

--- a/bioverse/functions.py
+++ b/bioverse/functions.py
@@ -4,6 +4,7 @@
 import os
 import glob
 import numpy as np
+from numpy.polynomial import Polynomial
 import pandas as pd
 import polars as pl
 import astropy.units as u
@@ -1011,8 +1012,7 @@ def classify_planets(d):
     return d
 
 def compute_habitable_zone_boundaries(d,HZ_formulation='K14'):
-    """ Computes the habitable zone boundaries from Kopparapu et al. (2014), including
-    dependence on planet mass.
+    """ Computes the habitable zone boundaries for a given formulation.
 
     Parameters
     ----------
@@ -1036,6 +1036,7 @@ def compute_habitable_zone_boundaries(d,HZ_formulation='K14'):
     if HZ_formulation == 'K14':
         #from Kopparapu et al. (2014), including dependence on planet mass.
         # Parameters for each planet mass and boundary (Table 1)
+        #boundaries are given by a polynomial in the form S= S_eff_sol+a*T+b*T^2 +c*T^3 + d*T^4
         M_ref = np.array([0.1,1.,5.])
         S_eff_sol = np.array([[1.776,0.99,0.356,0.32],
                               [1.776,1.107,0.356,0.32],
@@ -1079,27 +1080,37 @@ def compute_habitable_zone_boundaries(d,HZ_formulation='K14'):
         d['a0'] = d['a'] / (1 - d['e'] ** 2) ** 0.5
         return d
 
+    # Kopparapu+ 2013 and Ramirez+ 2018 parameterize the habitable zone boundaries in terms of
+    #   a fourth order polynomial in T= T_eff -T_eff_sun. Here we specify which set of coefficients
+    #   for the polynomial we should use.
     if HZ_formulation == 'K13':
         #Kopparapu+ 2013 HZ formulation
         C_inner=HZ_CONST['moist_greenhouse']
         C_outer=HZ_CONST['max_greenhouse']
+        # maximum temperature that this HZ model is valid for (K)
         T_max= 7200
     elif HZ_formulation == 'K13_optimistic':
         #Kopparapu+ 2013 optimistic HZ
         C_inner=HZ_CONST['recent_venus']
         C_outer=HZ_CONST['early_mars']
+        # maximum temperature that this HZ model is valid for (K)
         T_max= 7200
     elif HZ_formulation == 'R18':
         #Ramirez et al 2018 HZ
         C_inner=HZ_CONST['leconte']
         C_outer=HZ_CONST['CO2_max']
+        # maximum temperature that this HZ model is valid for (K)
         T_max= 10000
     else:
         raise ValueError('HZ formation not recognized')
 
     T_st = T_eff - 5780.
-    S_in = C_inner[0] + C_inner[1] * T_st + C_inner[2] * T_st ** 2 + C_inner[3] * T_st ** 3 + C_inner[4] * T_st ** 4
-    S_out = C_outer[0] + C_outer[1] * T_st + C_outer[2] * T_st ** 2 + C_outer[3] * T_st ** 3 + C_outer[4] * T_st ** 4
+    #this is equivalent to setting S_in=C_inner[0] + C_inner[1] * T_st + C_inner[2] * T_st ** 2 + C_inner[3] * T_st ** 3 + C_inner[4] * T_st ** 4
+    f_in= Polynomial(C_inner)
+    S_in = f_in(T_st)
+
+    f_out= Polynomial(C_outer)
+    S_out = f_out(T_st)
 
     d_in = (L/S_in)**0.5
     d_out = (L/S_out)**0.5
@@ -1114,9 +1125,6 @@ def compute_habitable_zone_boundaries(d,HZ_formulation='K14'):
     d['a0'] = d['a'] / (1 - d['e'] ** 2) ** 0.5
 
     return d
-
-
-
 
 def scale_height(d):
     """ Computes the equilibrium temperature and isothermal scale height


### PR DESCRIPTION
Added additional formulations of the habitable zone to Bioverse. Previously the `compute_habitable_zone_boundaries` function was limited to the Kopparapu et al. (2014) habitable zone formulation, which is not often used in the literature. That formulation calculates the habitable zone boundaries as a function of planet mass for 3 discrete planet masses. The Bioverse implementation interpolates these three scenarios for the entire range of planet masses, which adds computational overhead and may be outside of the scope of the original paper.

I've added the option for users to specify which formulation of the habitable zone they would like to use. This is included as the `HZ_formulation` keyword argument for `compute_habitable_zone_boundaries`. The Kopparapu+ 2014 HZ is still the default, but I've added three additional HZ formulations:

- Kopparapu et al. (2013) conservative habitable zone, using moist greenhouse and max greenhouse limits
- Kopparapu et al. (2013) optimistic habitable zone, using empirical constraints based on recent Venus and early Mars
- Ramirez et al. (2018) habitable zone, incorporating CH4 as a dominant greenhouse gas

Constants for the polynomial fits for the habitable zones of these papers are now saved in a dictionary in constants.py.  

I've tested these new habitable zone options on my end and they seem to be working properly. Using the default settings, the output is expected to be identical to previous versions (though this should be checked).