### PR TITLE
New noise calculation and survey type

### DIFF
--- a/bioverse/constants.py
+++ b/bioverse/constants.py
@@ -33,9 +33,9 @@ CONST['R_Sun'] = 6.9634e10
 CONST['h_Earth'] = 8.5e5
 CONST['P_Earth'] = 101325.
 CONST['S_Earth'] = 238.         # global-averaged, top-of-atmosphere insolation of Earth in W/m2. Scaled by an assumed albedo of 0.3.
-CONST['h'] =6.6261e-27
-CONST['c']= 2.9979e10
-CONST['k']= 1.3807e-16
+CONST['h'] =6.6261e-27 #cm^2 g/s
+CONST['c']= 2.9979e10 #cm/s
+CONST['k']= 1.3807e-16 #cm^2 g s^-2 K^-1
 
 # Data types
 ARRAY_TYPES = (np.ndarray,list,tuple)

--- a/bioverse/constants.py
+++ b/bioverse/constants.py
@@ -26,9 +26,10 @@ CONST['yr_to_day'] = 365.2422
 CONST['day_to_sec']=86400.0
 CONST['AU_to_solRad'] = 215.03215567054767
 CONST['rho_Earth'] = 5.51
-CONST['g_Earth'] = 980.7
+CONST['g_Earth'] = 980.7 #cm/s^2
 CONST['amu_to_kg'] = 1.66054e-27
-CONST['R_Earth'] = 6.371e8
+CONST['R_Earth'] = 6.371e8 #cm
+CONST['M_Earth'] = 5.9722e27 #g
 CONST['R_Sun'] = 6.9634e10
 CONST['h_Earth'] = 8.5e5
 CONST['P_Earth'] = 101325.
@@ -36,6 +37,7 @@ CONST['S_Earth'] = 238.         # global-averaged, top-of-atmosphere insolation 
 CONST['h'] =6.6261e-27 #cm^2 g/s
 CONST['c']= 2.9979e10 #cm/s
 CONST['k']= 1.3807e-16 #cm^2 g s^-2 K^-1
+CONST['G']= 6.67430e-8 #cgs units
 
 # Data types
 ARRAY_TYPES = (np.ndarray,list,tuple)

--- a/bioverse/functions.py
+++ b/bioverse/functions.py
@@ -54,7 +54,7 @@ def luminosity_evolution(d):
     return d
 
 sch_gcns= pl.Schema({'star_name': str, 'd': float,'ra': float, 'dec': float,'M_G': float, 'M_st': float,
-                    'R_st': float, 'L_st': float,'T_eff_st': int, 'SpT': str,'subSpT': str, 'binary': bool,
+                    'R_st': float, 'L_st': float,'T_eff_st': float, 'SpT': str,'subSpT': str, 'binary': bool,
                      'RV': float})
 
 def read_stars_Gaia(d, filename='gcns_catalog.dat', d_max=120., M_st_min=0.075, M_st_max=2.0, R_st_min=0.095,

--- a/bioverse/survey.py
+++ b/bioverse/survey.py
@@ -699,6 +699,7 @@ class TransitSurvey(Survey):
     #R: spectral resolution
     #feature_col: column with feature strength by default set to planet transit depth
     #feature_ppm: is feature strength given in ppm, false says feauture strength is a ratio
+    #kwargs: keyword args for calc_photometric_precision
     def fixed_field_yield(self, d, n_sigma=1.0, min_num_tr=1, t_fixed=None, t_exp=2.0, n_pix=108, R=20,
                           feature_col='depth', feature_ppm=False,**kwargs):
         if t_fixed is None:

--- a/bioverse/survey.py
+++ b/bioverse/survey.py
@@ -237,10 +237,6 @@ class Survey(dict, Object):
         t_exp = copy.deepcopy(d[texp_col]) #needs deepcopy or edits d in place
 
         t_over= np.zeros_like(t_exp) if zero_overhead else self.compute_overhead_time(d)
-        # if zero_overhead:
-        #     t_over= np.zeros_like(t_exp)
-        # else:
-        #     t_over = self.compute_overhead_time(d)
 
         t_total= self.t_max
         if t_total is None:
@@ -278,6 +274,7 @@ class Survey(dict, Object):
             if t_sum > t_total:
                 break
 
+            #this is inefficient
             if self.mode == 'imaging':
                 same_system= (d['starID'] == d['starID'][i])
                 t_exp[same_system] -= t_exp[i]
@@ -693,14 +690,26 @@ class TransitSurvey(Survey):
         d['photometric_precision'] = ppm_arr  # ppm
         return d
 
-    def fixed_field_yield(self, d, n_sigma=1.0, min_num_tr=1, t_fixed=None, t_exp=2.0, n_pix=108, R=20, **kwargs):
+    #d: table
+    #n_sigma: number of standard deviations in transit depth necessary for detection/characterization
+    #min_num_tr: minimum number of transits for a detection
+    #t_fixed: duration to observe field, set to survey duration by default (day)
+    #t_exp: time per ccd exposure (s)
+    #n_pix: number of pixels used on ccd
+    #R: spectral resolution
+    #feature_col: column with feature strength by default set to planet transit depth
+    #feature_ppm: is feature strength given in ppm, false says feauture strength is a ratio
+    def fixed_field_yield(self, d, n_sigma=1.0, min_num_tr=1, t_fixed=None, t_exp=2.0, n_pix=108, R=20,
+                          feature_col='depth', feature_ppm=False,**kwargs):
         if t_fixed is None:
             t_fixed=self.t_max
         if np.isinf(t_fixed) or np.isnan(t_fixed):
             return d
 
         d = self.calc_photometric_precision(d, t_fixed=t_fixed, t_exp=t_exp, n_pix=n_pix, R=R, **kwargs)
-        mask = (d['depth'] * 1e6) > (n_sigma * d['photometric_precision'])
+
+        mult= 1.0 if feature_ppm else 1e6
+        mask = (d[feature_col] * mult) > (n_sigma * d['photometric_precision'])
 
         # limit planet detection to planets with multiple transits
         mask2 = (d['N_obs'] >= min_num_tr)

--- a/bioverse/survey.py
+++ b/bioverse/survey.py
@@ -15,6 +15,8 @@ class Survey(dict, Object):
     diameter: float = 15.0 # in meters
     t_max: float = 10*365.25 #max survey duration in days
     t_slew: float = 0.00347 #slew time in days
+    FOV_center: np.ndarray = None #array of center(s) of each box field of view in RA and DEC (deg) #shape (nFOV,2) or (2)
+    FOV_size: np.ndarray = None #half width of FOV in degrees, shape: (nFOV,2) or (2)
     #debias: bool = False
 
     def __post_init__(self):
@@ -27,7 +29,8 @@ class Survey(dict, Object):
 
         # Casts all parameters to the correct type
         for field in fields(self):
-            self.__dict__[field.name] = field.type(self.__dict__[field.name])
+            if field.type != np.ndarray: #fails to cast None as np array
+                self.__dict__[field.name] = field.type(self.__dict__[field.name])
 
         # Update the parent reference in all of the Survey's measurements
         for measurement in self.measurements.values():
@@ -400,36 +403,61 @@ class Survey(dict, Object):
 
         return d
 
-    #should this be moved to functions, maybe we want to call it outside of survey
-    def in_telescope_FOV(d, box_centers=np.array([[util.RA0, util.DEC0]]), box_sizes=np.array([[util.HALF_RA, util.HALF_DEC]])):
+    def in_telescope_FOV(self,d):
         '''Function to filter objects based on whether they are in telescope field of view. Applicable for
         an array of telescopes such as Nautilus or Chronos
+
+        Relies on Survey.FOV_center, Survey.FOV_size
+        required format: numpy array of shape (nFOV,2) or (2) for RA and DEC centers and widths
+
+        if these are None, return results for whole sky
 
         Parameters
         -----------
         d : Table
             Table of all objects
-        box_centers : array-like
-            array of centers of each box FOV in RA and DEC (deg)
-            shape (nboxes,2) or (2)
-        box_sizes : array-like
-            size of each box in half RA and half DEC (deg)
-            shape (nboxes,2) or (2)
 
         Returns
         -----------
         d : Table
             Table of objects in the combined FOV
         '''
-        if len(box_centers.shape) == 1:
-            box_centers = box_centers.reshape(1, 2)
+        box_centers= self.FOV_center
+        box_sizes = self.FOV_size
 
+        if (box_centers is None) or (box_sizes is None):
+            return d
+
+        #ensure box_centers in shape (N,2)
+        if len(box_centers.shape) == 1:
+            if len(box_centers) == 2:
+                box_centers = box_centers.reshape(1, 2)
+            else:
+                raise Exception("Incorrect shape for FOV_center")
+        elif len(box_centers.shape) == 2:
+            if box_centers.shape[1] != 2:
+                raise Exception("Incorrect shape for FOV_center")
+        else:
+            raise Exception("Incorrect shape for FOV_center")
+
+        #ensure box_sizes in shape (N,2)
         if len(box_sizes.shape) == 1:
-            box_sizes = box_sizes.reshape(1, 2)
+            if len(box_sizes) == 2:
+                box_sizes = box_sizes.reshape(1, 2)
+            else:
+                raise Exception("Incorrect shape for FOV_size")
+        elif len(box_sizes.shape) == 2:
+            if box_sizes.shape[1] != 2:
+                raise Exception("Incorrect shape for FOV_size")
+        else:
+            raise Exception("Incorrect shape for FOV_size")
 
         n_boxes = len(box_centers)
         if len(box_sizes) != n_boxes:
-            box_sizes = np.repeat(box_sizes, n_boxes, axis=0)
+            if len(box_sizes)==1:
+                box_sizes = np.repeat(box_sizes, n_boxes, axis=0)
+            else:
+                raise Exception("Incompatible number of boxes and sizes")
 
         for q in range(n_boxes):
             box_mask = util.in_geodesic_box(d['ra'], d['dec'], ra0_deg=box_centers[q, 0], dec0_deg=box_centers[q, 1],
@@ -665,7 +693,12 @@ class TransitSurvey(Survey):
         d['photometric_precision'] = ppm_arr  # ppm
         return d
 
-    def fixed_field_yield(self, d, n_sigma=1.0, min_num_tr=1, t_fixed=60.0, t_exp=2.0, n_pix=108, R=20, **kwargs):
+    def fixed_field_yield(self, d, n_sigma=1.0, min_num_tr=1, t_fixed=None, t_exp=2.0, n_pix=108, R=20, **kwargs):
+        if t_fixed is None:
+            t_fixed=self.t_max
+        if np.isinf(t_fixed) or np.isnan(t_fixed):
+            return d
+
         d = self.calc_photometric_precision(d, t_fixed=t_fixed, t_exp=t_exp, n_pix=n_pix, R=R, **kwargs)
         mask = (d['depth'] * 1e6) > (n_sigma * d['photometric_precision'])
 
@@ -677,8 +710,7 @@ class TransitSurvey(Survey):
 
 
     def compute_yield(self, d0, method='detectable',debias=False,zero_overhead=False,**y_kwargs):
-        """ Computes a simple estimate of the detection yield for a transit survey. Currently all detectable transiting
-        planets are considered to be detected.
+        """ Computes a simple estimate of the detection yield for a transit survey. Select between multiple yield methods.
 
         Parameters
         ----------
@@ -725,15 +757,13 @@ class TransitSurvey(Survey):
             to_observe= self.schedule_observations(d,texp_col='t_exp',N_obs_col='N_obs',debias=debias,zero_overhead=zero_overhead)
             d= d[to_observe]
         elif method == 'fixed_field':
-
+            d = self.compute_detectable(d)
+            d= self.in_telescope_FOV(d) #currently in_telescope_FOV only called for fixed field method
             d = self.fixed_field_yield(d,**y_kwargs)  # should we make specific args explicit such as t_fixed?
-            #add sky area cut here?
 
         else:
             raise Exception('Method: {} not recognized'.format(method))
 
-        #add sky area constraint
-        #survey constraint
 
         # Return the output table
         return d

--- a/bioverse/survey.py
+++ b/bioverse/survey.py
@@ -221,6 +221,7 @@ class Survey(dict, Object):
         debias = d['a']/d['R_st']
         return debias
 
+
     def schedule_observations(self, d, texp_col='t_exp', N_obs_col='N_obs',debias=False,zero_overhead=False):
         if not hasattr(self, 'mode'):
             raise KeyError("No mode was specified for this survey.")
@@ -231,22 +232,22 @@ class Survey(dict, Object):
         weights = self.compute_weights(d)
 
         t_exp = copy.deepcopy(d[texp_col]) #needs deepcopy or edits d in place
-        if zero_overhead:
-            t_over= np.zeros_like(t_exp)
-        else:
-            t_over = self.compute_overhead_time(d)
+
+        t_over= np.zeros_like(t_exp) if zero_overhead else self.compute_overhead_time(d)
+        # if zero_overhead:
+        #     t_over= np.zeros_like(t_exp)
+        # else:
+        #     t_over = self.compute_overhead_time(d)
 
         t_total= self.t_max
         if t_total is None:
             raise Exception("Total Survey duration needs to be defined")
 
-        if self.mode == 'imaging':
-            pass
-        elif self.mode == 'transit':
+        #for transit missions: ensure that measurements don't exceed the maximum number of observations and survey duration
+        if self.mode == 'transit':
             if N_obs_col not in d:
                 raise KeyError("No N_obs column found in Table.")
             N_obs= d[N_obs_col]
-            # ensure that measurements don't exceed the maximum number of observations and survey duration
             weights[N_obs > self.N_obs_max]= 0
             weights[(N_obs*d['P']) > t_total] = 0
 
@@ -399,6 +400,47 @@ class Survey(dict, Object):
 
         return d
 
+    #should this be moved to functions, maybe we want to call it outside of survey
+    def in_telescope_FOV(d, box_centers=np.array([[util.RA0, util.DEC0]]), box_sizes=np.array([[util.HALF_RA, util.HALF_DEC]])):
+        '''Function to filter objects based on whether they are in telescope field of view. Applicable for
+        an array of telescopes such as Nautilus or Chronos
+
+        Parameters
+        -----------
+        d : Table
+            Table of all objects
+        box_centers : array-like
+            array of centers of each box FOV in RA and DEC (deg)
+            shape (nboxes,2) or (2)
+        box_sizes : array-like
+            size of each box in half RA and half DEC (deg)
+            shape (nboxes,2) or (2)
+
+        Returns
+        -----------
+        d : Table
+            Table of objects in the combined FOV
+        '''
+        if len(box_centers.shape) == 1:
+            box_centers = box_centers.reshape(1, 2)
+
+        if len(box_sizes.shape) == 1:
+            box_sizes = box_sizes.reshape(1, 2)
+
+        n_boxes = len(box_centers)
+        if len(box_sizes) != n_boxes:
+            box_sizes = np.repeat(box_sizes, n_boxes, axis=0)
+
+        for q in range(n_boxes):
+            box_mask = util.in_geodesic_box(d['ra'], d['dec'], ra0_deg=box_centers[q, 0], dec0_deg=box_centers[q, 1],
+                                       half_ra_deg=box_sizes[q, 0], half_dec_deg=box_sizes[q, 1])
+            if q == 0:
+                mask = box_mask
+            else:
+                mask = mask | box_mask
+
+        return d[mask]
+
 @dataclass(repr=False)
 class ImagingSurvey(Survey):
     inner_working_angle: float = 3.5
@@ -486,7 +528,7 @@ class ImagingSurvey(Survey):
         elif (method == 'exp_time') or (method=='blind_survey'): #may want to change name to blind_survey
             #assumes scheduling function has been run in generator
             if 't_req' not in d:
-                raise Exception("'t_ref' not found in Table. Be sure to run schedule survey before calling this function")
+                raise Exception("'t_req' not found in Table. Be sure to run schedule survey before calling this function")
 
             if 'ang_sep_mas' not in d:
                 d['ang_sep_mas'] = d['a'] / d['d'] * 1000
@@ -502,7 +544,6 @@ class ImagingSurvey(Survey):
 
             if 'Vmag' not in d:
                 raise KeyError("Missing V band, this function has only been tested to work for V band")
-                return
 
             d = self.call_exposure_time_calculator(d, SNR=SNR, band_width=band_width, band='Vmag',
                                                    C_col='contrast', sep_col='ang_sep_mas',
@@ -595,8 +636,47 @@ class TransitSurvey(Survey):
 
         return d[mask]
 
+    def calc_photometric_precision(self, d, t_fixed=60.0, t_exp=2.0, n_pix=108, R=20, **kwargs):
+        '''
+        Function to calculate the photometric precision of a survey
 
-    def compute_yield(self, d0, method='detectable',debias=False,zero_overhead=False,**ref_kwargs):
+        :param survey: bioverse survey object
+        :param d: bioverse table of planets
+        :param t_fixed: fixed field survey duration in days
+        :param t_exp: time for individual exposure in seconds
+        :param n_pix: number of pixels on detector
+        :param R: spectral resolution
+        :param kwargs: keyword arguments for SNR calculation/ fixed field yield function
+        :return: d
+        '''
+
+        D = self.diameter * 100  # in cm
+        N_tr = np.ceil(t_fixed / d['P'])  # maybe have t_fixed as an attribute of survey
+        t_int = d['T_dur'] * N_tr
+
+        d['N_obs'] = N_tr  # number of transits observed
+        d['t_int'] = t_int  # total in transit integration time (days)
+
+        t_int = t_int * CONST['day_to_sec']
+        nexp = t_int // t_exp
+
+        SNR_arr = util.SNR_calculator(d['Gmag'], D=D, t_exp=t_exp, R=R, n_exp=nexp, n_pix=n_pix, **kwargs)
+        ppm_arr = 1 / SNR_arr * 1e6
+        d['photometric_precision'] = ppm_arr  # ppm
+        return d
+
+    def fixed_field_yield(self, d, n_sigma=1.0, min_num_tr=1, t_fixed=60.0, t_exp=2.0, n_pix=108, R=20, **kwargs):
+        d = self.calc_photometric_precision(d, t_fixed=t_fixed, t_exp=t_exp, n_pix=n_pix, R=R, **kwargs)
+        mask = (d['depth'] * 1e6) > (n_sigma * d['photometric_precision'])
+
+        # limit planet detection to planets with multiple transits
+        mask2 = (d['N_obs'] >= min_num_tr)
+
+        # could also add a minimum number of transits observed here
+        return d[mask & mask2]
+
+
+    def compute_yield(self, d0, method='detectable',debias=False,zero_overhead=False,**y_kwargs):
         """ Computes a simple estimate of the detection yield for a transit survey. Currently all detectable transiting
         planets are considered to be detected.
 
@@ -613,8 +693,10 @@ class TransitSurvey(Survey):
             Apply debias correction for transiting planets.
         zero_overhead : bool, optional
             set overhead to zero
-        ref_kwargs : dict, optional
-            sets reference observation, updates self.reference
+        y_kwargs : dict, optional
+            keyword arges for specific yield method
+            for "scaling relation": sets reference observation, updates self.reference
+            for "fixed field": kwargs for SNR calculator
 
         Returns
         -------
@@ -630,7 +712,7 @@ class TransitSurvey(Survey):
             #adapt alex's target prioritization here + overheads
             #originally in measurement object
 
-            self.reference.update({**ref_kwargs})
+            self.reference.update({**y_kwargs})
 
             #ensure that scaling law has dictionary of reference values
             req_keys={'t_ref', 'wl_eff', 'T_st_ref', 'R_st_ref', 'D_ref', 'd_ref', 'R_pl_ref', 'H_ref'}
@@ -642,6 +724,11 @@ class TransitSurvey(Survey):
             d= self.exp_time_scaling_relation(d,**self.reference)
             to_observe= self.schedule_observations(d,texp_col='t_exp',N_obs_col='N_obs',debias=debias,zero_overhead=zero_overhead)
             d= d[to_observe]
+        elif method == 'fixed_field':
+
+            d = self.fixed_field_yield(d,**y_kwargs)  # should we make specific args explicit such as t_fixed?
+            #add sky area cut here?
+
         else:
             raise Exception('Method: {} not recognized'.format(method))
 
@@ -651,9 +738,6 @@ class TransitSurvey(Survey):
         # Return the output table
         return d
 
-
-
-#needs major work after recent changes
 class Measurement():
     """
     Class describing a simple measurement to be applied to a set of planets detected by a Survey.
@@ -707,9 +791,6 @@ class Measurement():
             #moved this from outside if statement
             data['planetID'] = detected['planetID']
             data['starID'] = detected['starID']
-        
-        # Determine which planets are valid targets and can be observed in the allotted time
-        #observable = self.compute_observable_targets(data, t_total)
 
         # Simulate a measurement for each observable planet
         x, dx = self.perform_measurement(detected[self.key])

--- a/bioverse/util.py
+++ b/bioverse/util.py
@@ -847,8 +847,8 @@ def SNR_calculator(Gmag,
     area = eta_tele * np.pi * (D / 2) ** 2
 
     #calculate the focal length, use it to compute pixel scale
+    #f number required fot background noise
     f_mm = f_number * (D * 1.0e1)
-    #this may be Chronos specific
     pix_scale = pixel_scale_arcsec_per_pix(pix_size, f_mm) #arcsec/pix
     solid_angle= n_pix*pix_scale**2 #arcsec^2
 

--- a/bioverse/util.py
+++ b/bioverse/util.py
@@ -816,9 +816,9 @@ def DI_exposure_time_calculator(contrast, sep_mas, D, mag_star, lambda_ref=550.,
     t_exp= t_exp/CONST['day_to_sec']
     return t_exp
 
-#compute pixel scale, may be specific to Chronos architecture
+#compute pixel scale
 def pixel_scale_arcsec_per_pix(pixel_um, f_mm):
-    return 206.265 * (pixel_um / f_mm)
+    return 206.265 * (pixel_um / f_mm)  #206265 arcsec per radian
 
 #SNR calculator for transit observations
 #currently only tested for Gmag

--- a/bioverse/util.py
+++ b/bioverse/util.py
@@ -708,6 +708,25 @@ def contrast_to_dmag(contrast):
     dmag= -2.5 * np.log10(contrast)
     return dmag
 
+def mag_to_flux(mag,zero_pt):
+    """
+    calculates flux from magnitude and zero point
+
+    Parameters
+    ------------
+    mag : float
+        object magnitude
+    zero_pt : float
+        flux zero point
+
+    Returns
+    -------------
+    F : float
+        flux (same units as zero point)
+    """
+    F= zero_pt*10**(-mag/2.5)
+    return F
+
 def DI_exposure_time_calculator(contrast, sep_mas, D, mag_star, lambda_ref=550.,
                                     F_0=10375.7, SNR=7, IWA=3.5, OWA=64.0, logcontrast_limit=-10.6,
                                     band_width=1.0/140.0):
@@ -796,3 +815,165 @@ def DI_exposure_time_calculator(contrast, sep_mas, D, mag_star, lambda_ref=550.,
     t_exp = pow(SNR, 2) * (CR_p + 2 * CR_b) / pow(CR_p, 2)  # in seconds
     t_exp= t_exp/CONST['day_to_sec']
     return t_exp
+
+#compute pixel scale, may be specific to Chronos architecture
+def pixel_scale_arcsec_per_pix(pixel_um, f_mm):
+    return 206.265 * (pixel_um / f_mm)
+
+#SNR calculator for transit observations
+#currently only tested for Gmag
+def SNR_calculator(Gmag,
+                   R=20,
+                   wl=0.621759, #um
+                   D= 50,#diameter cm
+                   f_number = 2.7, #F number of lens
+                   eta_tele=1.0,
+                   t_exp=2.0, #s
+                   n_exp=300,
+                   n_pix=108,
+                   pix_size=20.0, #um
+                   F0_G=2.503844769366081e-05, #G band zero point, erg/s/cm2/um
+                   lam_center=0.621759, #G band center wavelength, um
+                   eta_eff=1.0,
+                   read_noise= 1.0, #e-/pix
+                   dark_current=0.05 #e-/s/pix
+                   ):
+    #add logic for if Gmag, t_exp, n_exp are arrays to ensure they are same length
+
+    F_G = mag_to_flux(Gmag, F0_G)
+    dlambda = wl / R  # um
+    area = eta_tele * np.pi * (D / 2) ** 2
+
+    #calculate the focal length, use it to compute pixel scale
+    f_mm = f_number * (D * 1.0e1)
+    #this may be Chronos specific
+    pix_scale = pixel_scale_arcsec_per_pix(pix_size, f_mm) #arcsec/pix
+    solid_angle= n_pix*pix_scale**2 #arcsec^2
+
+    E_phot = CONST['h'] * CONST['c'] / (wl * 1.0e-4)  # erg
+    F_to_e_factor = eta_eff * area * n_exp * t_exp * dlambda / E_phot
+
+    N_source = F_to_e_factor * F_G
+
+    #average zodi brightness 22.5 mag / arcsec2
+    z= 22.5  #assume roughly same in G band as in V band
+    F_back = F0_G * (10**(-0.4*z)) * solid_angle
+    N_back = F_to_e_factor * F_back
+    N_optics = 0
+    N_ground = 0
+    N_D = n_pix * n_exp * (read_noise ** 2 + dark_current * t_exp)  # is this equation correct, listed in PSG documentation
+    N_tot = np.sqrt(2 * N_D + N_source + 2 * N_back + 2 * N_optics + 2 * N_ground)
+
+    SNR = N_source / N_tot
+    return SNR
+
+
+#calculate required number of exposures to achieve a given SNR
+#inverts SNR_calculator
+#assumes t_exp is fixed
+#total integration time is t_exp*n_exp
+def calc_nexp(Gmag,SNR=6,
+                   R=20,
+                   wl=0.621759, #um
+                   D= 50,#diameter cm
+                   f_number = 2.7, #F number of lens
+                   eta_tele=1.0,
+                   t_exp=2.0, #s
+                   n_pix=108,
+                   pix_size=20.0, #um
+                   F0_G=2.503844769366081e-05, #G band zero point, erg/s/cm2/um
+                   lam_center=0.621759, #G band center wavelength, um
+                   eta_eff=1.0,
+                   read_noise= 1.0, #e-/pix
+                   dark_current=0.05 #e-/s/pix
+                   ):
+    #add logic for if Gmag, t_exp, n_exp are arrays to ensure they are same length
+
+    F_G = mag_to_flux(Gmag, F0_G)
+    dlambda = wl / R  # um
+    area = eta_tele * np.pi * (D / 2) ** 2
+
+    #calculate the focal length, use it to compute pixel scale
+    f_mm = f_number * (D * 1.0e1)
+    #this may be Chronos specific
+    pix_scale = pixel_scale_arcsec_per_pix(pix_size, f_mm) #arcsec/pix
+    solid_angle= n_pix*pix_scale**2 #arcsec^2
+
+    E_phot = CONST['h'] * CONST['c'] / (wl * 1.0e-4)  # erg
+
+    Cs= eta_eff*area*t_exp*dlambda*F_G / E_phot
+
+    #average zodi brightness 22.5 mag / arcsec2
+    z= 22.5  #assume roughly same in G band as in V band
+    F_back = F0_G * (10**(-0.4*z)) * solid_angle
+    Cb= eta_eff*area*t_exp*dlambda*F_back / E_phot
+
+    #N_optics = 0
+    #N_ground = 0
+    Cd = n_pix * (read_noise ** 2 + dark_current * t_exp)  # is this equation correct, listed in PSG documentation
+
+    n_exp= ((2*Cd+Cs+2*Cb)/(Cs**2))*SNR**2
+    return n_exp
+
+RA0 = 290.67        # deg
+DEC0 = 44.5         # deg
+HALF_RA = 65.159/2      # deg  #scenario I
+HALF_DEC = 60.815 / 2  # deg #scenario I
+
+def in_geodesic_box(ra_deg, dec_deg,
+                    ra0_deg=RA0, dec0_deg=DEC0,
+                    half_ra_deg=HALF_RA,
+                    half_dec_deg=HALF_DEC):
+    """
+    Return True/False for points inside a geodesic rectangle centered at
+    (ra0, dec0), with half-sizes interpreted as GREAT-CIRCLE half-angles.
+
+    This version avoids mirrored gnomonic-projection solutions by requiring
+    the source to be on the front hemisphere of the tangent point.
+
+    credit Chia-Lung
+    """
+
+    ra_deg  = np.asanyarray(ra_deg)
+    dec_deg = np.asanyarray(dec_deg)
+
+    ra   = np.deg2rad(ra_deg)
+    dec  = np.deg2rad(dec_deg)
+    ra0  = np.deg2rad(ra0_deg)
+    dec0 = np.deg2rad(dec0_deg)
+
+    dra = ra - ra0
+
+    # Gnomonic projection denominator.
+    # This is cos(c), where c is the angular distance from the field center.
+    cosc = (
+        np.sin(dec0) * np.sin(dec)
+        + np.cos(dec0) * np.cos(dec) * np.cos(dra)
+    )
+
+    # Reject the back side of the tangent plane.
+    # This is the key part that removes mirrored solutions.
+    front = cosc > 0
+
+    # Initialize projected coordinates as NaN
+    xi  = np.full_like(ra, np.nan, dtype=float)
+    eta = np.full_like(dec, np.nan, dtype=float)
+
+    # Only project valid front-side points
+    xi[front] = (
+        np.cos(dec[front]) * np.sin(dra[front])
+        / cosc[front]
+    )
+
+    eta[front] = (
+        np.cos(dec0) * np.sin(dec[front])
+        - np.sin(dec0) * np.cos(dec[front]) * np.cos(dra[front])
+    ) / cosc[front]
+
+    xi_lim  = np.tan(np.deg2rad(half_ra_deg))
+    eta_lim = np.tan(np.deg2rad(half_dec_deg))
+
+    inside_x = np.abs(xi)  <= xi_lim
+    inside_y = np.abs(eta) <= eta_lim
+
+    return front & inside_x & inside_y

--- a/bioverse/util.py
+++ b/bioverse/util.py
@@ -993,3 +993,9 @@ def in_geodesic_box(ra_deg, dec_deg,
     inside_y = np.abs(eta) <= eta_lim
 
     return front & inside_x & inside_y
+
+def compute_logg(M,R):
+    M=M*CONST['M_Earth'] #to g
+    R=R* CONST['R_Earth'] #to cm
+    g=CONST['G']*M / R**2
+    return np.log10(g)

--- a/bioverse/util.py
+++ b/bioverse/util.py
@@ -836,7 +836,9 @@ def SNR_calculator(Gmag,
                    lam_center=0.621759, #G band center wavelength, um
                    eta_eff=1.0,
                    read_noise= 1.0, #e-/pix
-                   dark_current=0.05 #e-/s/pix
+                   dark_current=0.05, #e-/s/pix
+                   background_noise=True,
+                   detector_noise=True
                    ):
     #add logic for if Gmag, t_exp, n_exp are arrays to ensure they are same length
 
@@ -857,12 +859,18 @@ def SNR_calculator(Gmag,
 
     #average zodi brightness 22.5 mag / arcsec2
     z= 22.5  #assume roughly same in G band as in V band
-    F_back = F0_G * (10**(-0.4*z)) * solid_angle
-    N_back = F_to_e_factor * F_back
+    if background_noise:
+        F_back = F0_G * (10**(-0.4*z)) * solid_angle
+        N_back = F_to_e_factor * F_back
+    else:
+        N_back = 0
     N_optics = 0
     N_ground = 0
-    N_D = n_pix * n_exp * (read_noise ** 2 + dark_current * t_exp)  # is this equation correct, listed in PSG documentation
-    N_tot = np.sqrt(2 * N_D + N_source + 2 * N_back + 2 * N_optics + 2 * N_ground)
+    if detector_noise:
+        N_D = n_pix * n_exp * (read_noise ** 2 + dark_current * t_exp)  # is this equation correct, listed in PSG documentation
+    else:
+        N_D = 0
+    N_tot = np.sqrt(2 * N_D + N_source + 2 * N_back + 2 * N_optics + 2 * N_ground) #factor of 2 from typical ON-OFF observation, see psg documentation
 
     SNR = N_source / N_tot
     return SNR
@@ -885,7 +893,9 @@ def calc_nexp(Gmag,SNR=6,
                    lam_center=0.621759, #G band center wavelength, um
                    eta_eff=1.0,
                    read_noise= 1.0, #e-/pix
-                   dark_current=0.05 #e-/s/pix
+                   dark_current=0.05, #e-/s/pix
+                   background_noise=True,
+                   detector_noise=True
                    ):
     #add logic for if Gmag, t_exp, n_exp are arrays to ensure they are same length
 
@@ -905,12 +915,18 @@ def calc_nexp(Gmag,SNR=6,
 
     #average zodi brightness 22.5 mag / arcsec2
     z= 22.5  #assume roughly same in G band as in V band
-    F_back = F0_G * (10**(-0.4*z)) * solid_angle
-    Cb= eta_eff*area*t_exp*dlambda*F_back / E_phot
+    if background_noise:
+        F_back = F0_G * (10**(-0.4*z)) * solid_angle
+        Cb= eta_eff*area*t_exp*dlambda*F_back / E_phot
+    else:
+        Cb= 0
 
     #N_optics = 0
     #N_ground = 0
-    Cd = n_pix * (read_noise ** 2 + dark_current * t_exp)  # is this equation correct, listed in PSG documentation
+    if detector_noise:
+        Cd = n_pix * (read_noise ** 2 + dark_current * t_exp)
+    else:
+        Cd = 0
 
     n_exp= ((2*Cd+Cs+2*Cb)/(Cs**2))*SNR**2
     return n_exp


### PR DESCRIPTION
In this pull request I add a new noise calculator to Bioverse allowing us to calculate the total integration time or number of transits required to recover features in a planet's spectrum. 

The function `util.SNR_calculator` calculates the signal to noise ratio for an object with a given G magnitude, and user supplied keyword arguments for the observatory and detector properties and the resolution and wavelength range of the spectrum.

`survey.TransitSurvey.calc_photometric_precision` uses this SNR calculator to compute the photometric precision for each planet in a survey, assuming that all transits in a given duration are observed.

`survey.TransitSurvey.compute_yield` now has a new method argument for a fixed field survey focusing on observing a specific region of the sky for a fixed duration.

To facilitate this Chia-lung Lin provided us with code he wrote previously in the context of yield modeling for the Chronos mission concept, which determines whether a star falls within the viewing area of a telescope or constellation of telescopes. I adapted these scripts to create a bioverse function `survey.Survey.in_telescope_fov` which is called by the compute_yield function. By default if the survey object has no defined field of view, it assumes the whole sky is potentially observable (prior to computing integration times)

These functions are working properly in the context of my current project, but additional tests in other contexts might be warranted.